### PR TITLE
Fix task count showing wrong count 

### DIFF
--- a/src/components/home/index.jsx
+++ b/src/components/home/index.jsx
@@ -48,7 +48,7 @@ function Home() {
               {appConstants.days.map((day, ind) =>
               (<tr key={ind}>
                 <DayCell value={toTitleCase(day)} />
-                <TaskCountCell value={itemCount[day]} />
+                <TaskCountCell value={choreList[day].filter(chore => chore?.title && chore.title.trim() !== "").length} />
                 {choreList[day].map((chore, ind) =>
                 (<TaskCell
                   key={ind}


### PR DESCRIPTION
Closes #17 

This PR fixes the task count showing the wrong count when the task is an empty string 